### PR TITLE
fix macos unable to build form at startup

### DIFF
--- a/nyalcf_gui/lib/main.dart
+++ b/nyalcf_gui/lib/main.dart
@@ -40,39 +40,37 @@ import 'package:window_manager/window_manager.dart';
 final _appLinks = AppLinks();
 
 void main() async {
-
-  /// 初始化配置文件等
-  await PathProvider.loadSyncPath();
-
-  /// 初始化数据存储
-  await StoragesInjector.init();
-
-  /// 初始化 Logger
-  await Logger.init();
-  Logger.debug(Platform.operatingSystem);
-  Logger.debug('Append info has been set: $appendInfo');
-
-  /// 自动旧版迁移数据
-  final appSupportParentPath = Directory(appSupportPath!).parent.parent.path;
-  if (Directory('$appSupportParentPath/moe.xmcn.nyanana').existsSync()) {
-    if (!Directory('$appSupportParentPath/moe.muska.ami').existsSync()) {
-      Directory('$appSupportParentPath/moe.muska.ami').createSync();
-    }
-    try {
-      await moveDirectory(
-        Directory('$appSupportParentPath/moe.xmcn.nyanana/nyanana'),
-        Directory('$appSupportParentPath/moe.muska.ami/nyanana'),
-      );
-    } catch (e, st) {
-      Logger.error('Could not automatic move launcher data to new folder!');
-      Logger.error(e, t: st);
-    }
-  }
-
-  /// 运行 App
   runZonedGuarded(() async {
-    /// 确保前置内容完成初始化
     WidgetsFlutterBinding.ensureInitialized();
+    
+    /// 初始化配置文件等
+    await PathProvider.loadSyncPath();
+
+    /// 初始化数据存储
+    await StoragesInjector.init();
+
+    /// 初始化 Logger
+    await Logger.init();
+    Logger.debug(Platform.operatingSystem);
+    Logger.debug('Append info has been set: $appendInfo');
+
+    /// 自动旧版迁移数据
+    final appSupportParentPath = Directory(appSupportPath!).parent.parent.path;
+    if (Directory('$appSupportParentPath/moe.xmcn.nyanana').existsSync()) {
+      if (!Directory('$appSupportParentPath/moe.muska.ami').existsSync()) {
+        Directory('$appSupportParentPath/moe.muska.ami').createSync();
+      }
+      try {
+        await moveDirectory(
+          Directory('$appSupportParentPath/moe.xmcn.nyanana/nyanana'),
+          Directory('$appSupportParentPath/moe.muska.ami/nyanana'),
+        );
+      } catch (e, st) {
+        Logger.error('Could not automatic move launcher data to new folder!');
+        Logger.error(e, t: st);
+      }
+    }
+    
     await windowManager.ensureInitialized();
 
     /// 读取信息


### PR DESCRIPTION
###修复 macos 启动时无法构建窗体  #241 
面向 gemini 编程，以下为 gemini 输出：
问题的根源在于 PathProvider.loadSyncPath() 需要在 WidgetsFlutterBinding.ensureInitialized()
  之后调用，而 runApp 又需要在 runZonedGuarded 内部调用。

  为了解决这个问题，我们需要在 runZonedGuarded 内部，但在 runApp 之前，完成所有的初始化作。

  正确的顺序应该是这样的：

   1. runZonedGuarded
   2. WidgetsFlutterBinding.ensureInitialized()
   3. PathProvider.loadSyncPath()
   4. StoragesInjector.init()
   5. Logger.init()
   6. ... 其他初始化
   7. runApp(const App())